### PR TITLE
feat: Add atlas user jupyter lab config file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,4 +62,12 @@ RUN . /release_setup.sh && \
 
 USER atlas
 
+# Setup environment for default user 'atlas'
+RUN echo -e '\n# Activate AnalysisBase environment on login shell\n. /release_setup.sh\n' >> /home/atlas/.bashrc && \
+    . /release_setup.sh && \
+    mkdir -p $(jupyter --config)
+
+# $(jupyter --config) should be /home/atlas/.jupyter/
+COPY --chown=atlas docker/jupyter_lab_config.py /home/atlas/.jupyter/
+
 CMD [ "/cmd.sh" ]

--- a/docker/jupyter_lab_config.py
+++ b/docker/jupyter_lab_config.py
@@ -1,0 +1,30 @@
+# Configuration file for lab.
+
+c = get_config()  #noqa
+
+## DEPRECATED in 2.0. Use PasswordIdentityProvider.allow_password_change
+#  Default: True
+c.ServerApp.allow_password_change = False
+
+## The IP address the Jupyter server will listen on.
+#  Default: 'localhost'
+c.ServerApp.ip = '0.0.0.0'
+
+## Whether to open in a browser after starting.
+#                          The specific browser used is platform dependent and
+#                          determined by the python standard library `webbrowser`
+#                          module, unless it is overridden using the --browser
+#                          (ServerApp.browser) configuration option.
+#  Default: False
+c.ServerApp.open_browser = False
+
+## The port the server will listen on (env: JUPYTER_PORT).
+#  Default: 0
+# Choose 9999 to match UChicago AF preferences
+c.ServerApp.port = 9999
+
+## Supply overrides for terminado. Currently only supports "shell_command".
+#  Default: {}
+# Set shell to bash as AnalysisBase assumes it
+# force login shell to pickup ~/.bash_profile
+c.ServerApp.terminado_settings = { "shell_command": ["/bin/bash", "-l"] }


### PR DESCRIPTION
* Add sourcing of /release_setup.sh to /home/atlas/.bash_profile to setup the AnalysisBase environment on login shells.
* Add Jupyter Lab config file to /home/atlas/.jupyter with defualts as well as a default jupyter lab shell of a login bash shell.