### PR TITLE
fix: Patch uproot for xrootd access

### DIFF
--- a/docker/requirements.lock
+++ b/docker/requirements.lock
@@ -764,6 +764,12 @@ fsspec==2023.10.0 \
     # via
     #   coffea
     #   dask
+    #   fsspec-xrootd
+    #   uproot
+fsspec-xrootd==0.2.2 \
+    --hash=sha256:107644704b2bb36e1fc8d7f81f2e55e0bb34d7bc12b74ff4f2ffabf65bfcf79e \
+    --hash=sha256:37ee9ea99ee866d685e0442dc5b5f6bb3114dc4abc05c4c5f7d986a25509cc8e
+    # via -r requirements.txt
 google-auth==2.23.4 \
     --hash=sha256:79905d6b1652187def79d491d6e23d0cbb3a21d3c7ba0dbaa9c8a01906b13ff3 \
     --hash=sha256:d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2
@@ -2273,9 +2279,8 @@ uhi==0.4.0 \
     # via
     #   histoprint
     #   mplhep
-uproot==5.1.2 \
-    --hash=sha256:99d0896ee83f2bed0e7112e8abccf22e7b749c63cf8785ac65a81b7e4d913d68 \
-    --hash=sha256:f69ee9381243cb0fea58c01a94a8a7abee29de3b67cdb9c9c9cccdd2caccd934
+uproot @ https://github.com/scikit-hep/uproot5/archive/0ace10af972ba825d98c28fa7df97cd3ef0b480f.zip \
+    --hash=sha256:680b9a7571f9a17ad4a9e3bc3caa0abb9a47ef92665990ee7d646cff74b303f2
     # via
     #   -r requirements.txt
     #   coffea

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,9 @@
-uproot==5.1.2
+# uproot==5.1.2
+# c.f. https://github.com/scikit-hep/uproot5/issues/1038
+uproot @ https://github.com/scikit-hep/uproot5/archive/0ace10af972ba825d98c28fa7df97cd3ef0b480f.zip
 dask[distributed]==2023.11.0
 dask-awkward==2023.11.2
+fsspec-xrootd==0.2.2
 # Z->ee notebook
 coffea==2023.10.0rc1
 zstandard==0.22.0


### PR DESCRIPTION
* Install a precursor to `uproot` `v5.2.0rc2` from GitHub and install `fsspec-xrootd` to provide support for xrootd access from uproot.
   - c.f. https://github.com/scikit-hep/uproot5/issues/1038
   - Note: This should be changed to an install from PyPI as soon as a release candidate is available for stability/reproducibility.
* Rebuild lock file.

```
* Install a precursor to uproot v5.2.0rc2 from GitHub and install
  fsspec-xrootd to provide support for xrootd access from uproot.
   - c.f. https://github.com/scikit-hep/uproot5/issues/1038
   - Note: This should be changed to an install from PyPI as soon as a
     release candidate is available for stability/reproducibility.
* Rebuild lock file.
```