### PR TITLE
feat: Add ENTRYPOINT and tini to support Dask KubeCluster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,6 +84,6 @@ RUN echo -e '\n# Activate AnalysisBase environment on login shell\n. /release_se
 # $(jupyter --config) should be /home/atlas/.jupyter/
 COPY --chown=atlas docker/jupyter_lab_config.py /home/atlas/.jupyter/
 
-ENTRYPOINT ["tini", "-g", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/tini", "-g", "--", "/entrypoint.sh"]
 
 CMD [ "/cmd.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,8 @@ COPY --chown=atlas docker/requirements.lock /docker/
 COPY --chown=atlas analysis /analysis
 WORKDIR /analysis
 
-COPY --chown=atlas /docker/cmd.sh /cmd.sh
 COPY --chown=atlas /docker/entrypoint.sh /entrypoint.sh
+COPY --chown=atlas /docker/cmd.sh /cmd.sh
 
 RUN echo -e '\n# Activate python virtual environment\nif [ -d /venv/bin ]; then\n    . /venv/bin/activate\nfi' >> /release_setup.sh && \
     bash <(curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/v0.0.5/cvmfs-venv.sh) /venv && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN yum install -y \
 # Add Tini
 ENV TINI_VERSION=v0.19.0
 ADD --chown=atlas https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
 
 COPY --chown=atlas docker/requirements.txt /docker/
 COPY --chown=atlas docker/requirements.lock /docker/
@@ -39,7 +38,9 @@ RUN echo -e '\n# Activate python virtual environment\nif [ -d /venv/bin ]; then\
     python -m pip list && \
     root --version
 
-RUN chmod +x /entrypoint.sh && \
+RUN chmod +x /tini && \
+    chmod +x /entrypoint.sh && \
+    chmod +x /cmd.sh && \
     chmod +x /release_setup.sh
 
 # Need to use an additonal directory beyond /usr/AnalysisBase to install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,18 @@ RUN yum install -y \
         graphviz && \
     yum clean all
 
+# Add Tini
+ENV TINI_VERSION=v0.19.0
+ADD --chown=atlas https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 COPY --chown=atlas docker/requirements.txt /docker/
 COPY --chown=atlas docker/requirements.lock /docker/
 COPY --chown=atlas analysis /analysis
 WORKDIR /analysis
 
 COPY --chown=atlas /docker/cmd.sh /cmd.sh
+COPY --chown=atlas /docker/entrypoint.sh /entrypoint.sh
 
 RUN echo -e '\n# Activate python virtual environment\nif [ -d /venv/bin ]; then\n    . /venv/bin/activate\nfi' >> /release_setup.sh && \
     bash <(curl -sL https://raw.githubusercontent.com/matthewfeickert/cvmfs-venv/v0.0.5/cvmfs-venv.sh) /venv && \
@@ -33,7 +39,8 @@ RUN echo -e '\n# Activate python virtual environment\nif [ -d /venv/bin ]; then\
     python -m pip list && \
     root --version
 
-RUN chmod +x /release_setup.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /release_setup.sh
 
 # Need to use an additonal directory beyond /usr/AnalysisBase to install
 # given how ATLAS CMake works.
@@ -75,5 +82,7 @@ RUN echo -e '\n# Activate AnalysisBase environment on login shell\n. /release_se
 
 # $(jupyter --config) should be /home/atlas/.jupyter/
 COPY --chown=atlas docker/jupyter_lab_config.py /home/atlas/.jupyter/
+
+ENTRYPOINT ["tini", "-g", "--", "/entrypoint.sh"]
 
 CMD [ "/cmd.sh" ]

--- a/docker/cmd.sh
+++ b/docker/cmd.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-. /release_setup.sh
-
 jupyter lab --no-browser --ip 0.0.0.0 --port 8888

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. /release_setup.sh
+
+# Run extra commands
+exec "$@"


### PR DESCRIPTION
To better support custom initalization of Dask KubeCluster container args, switch to using an `ENTRYPOINT` with `tini`.

For Dask KubeCluster, to customize the arguments passed to the container, `spec["spec"]["scheduler"]["spec"]["containers"][0]["args"]` (or `"worker"`) expects that the args are able to be given directly as the container `CMD` without any additional setup. To ensure environmental setup in advance, an `ENTRYPOINT` should be used instead, as is done in https://github.com/dask/dask-docker/blob/fcb9fb839fb1085714b2ee4cbaca1c910ded5bba/base/Dockerfile#L32.

```
* Use an ENTRYPOINT to ensure /release_setup.sh is sourced to provide the
  correct environment.
   - For customized container commands to be given to Dask KubeClusters the
     args need to be able to be passed as CMD without additional environmental
     setup or an additional shell being spawned.
   - c.f. https://kubernetes.dask.org/en/latest/operator_kubecluster.html#customising-your-cluster
* Use tini to better support and guard this behavior.
   - c.f. https://github.com/krallin/tini
```