### PR TITLE
feat: Update ServiceX client to v3.0.0a17

### DIFF
--- a/docker/requirements.lock
+++ b/docker/requirements.lock
@@ -2494,9 +2494,9 @@ send2trash==1.8.3 \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
     # via jupyter-server
-servicex==3.0.0a16 \
-    --hash=sha256:092a8380385ffc37a224963d48103a9587d6b24c19b5c696b88f7cb68674bf90 \
-    --hash=sha256:145a718b8405385d4d3542daf52284ae19969ff281c4c870cfeadbc95b49002d
+servicex==3.0.0a17 \
+    --hash=sha256:196466544fd43b91f981c03763620c57c1bfbd4d671f8af38dccf5d824b178e4 \
+    --hash=sha256:97e92b154f92743b74792434d1ad3e0e0bfa407d8af554e8ac780063bb4164c2
     # via func-adl-servicex
 setuptools==69.5.1 \
     --hash=sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987 \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -24,6 +24,6 @@ ipywidgets==8.1.2
 graphviz==0.20.3
 jupyter-server-proxy==4.1.2
 # servicex
-servicex==3.0.0a16
+servicex==3.0.0a17
 func-adl-servicex==2.2
 func_adl_servicex_xaodr22==2.0.0.22.2.107a12


### PR DESCRIPTION
* Update ServiceX client to 3.0 alpha 17.
   - c.f. https://github.com/ssl-hep/ServiceX_frontend/releases/tag/3.0.0-alpha.17
* Rebuild the lock file.