### PR TITLE
fix: Use uproot from GitHub until release v5.3.12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,8 @@ RUN echo -e '\n# Activate python virtual environment\nif [ -d /venv/bin ]; then\
     --no-deps \
     --require-hashes \
     --requirement /docker/requirements.lock && \
+    python -m pip uninstall --yes uproot && \
+    python -m pip --no-cache-dir install --upgrade "uproot @ git+https://github.com/scikit-hep/uproot5.git@adf831ebe2824eea669f7cb6e1046adbb3d17d93" && \
     chown -R atlas /venv && \
     python --version --version && \
     python -m pip list && \


### PR DESCRIPTION
Install uproot from https://github.com/scikit-hep/uproot5/tree/aa8b94f722982c6eb418f9f32273152039836fb2 to use the fix from https://github.com/scikit-hep/uproot5/pull/1280 until uproot v5.3.12 is released.

cc @alexander-held